### PR TITLE
Build with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,20 +10,12 @@
 # dfx temporary files
 .dfx/
 
-# generated files
-**/declarations/
-utils/canister_upgrade_pipeline/
-utils/canister_call_pipeline/
-
 # rust
 target/
+release-artifacts/
 
 # frontend code
 node_modules/
 dist/
-.svelte-kit/
+public
 
-# environment variables
-.env
-
-release-artifacts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM --platform=linux/amd64 ubuntu:24.04
+
+ENV RUSTUP_HOME=/opt/rustup
+ENV CARGO_HOME=/opt/cargo
+
+# Install a basic environment needed for our build tools
+RUN apt -yq update && \
+    apt -yqq install --no-install-recommends curl ca-certificates \
+        build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake rsync libunwind-dev jq
+
+# Install Rust and Cargo
+ENV PATH=/opt/cargo/bin:${PATH}
+COPY rust-toolchain.toml ./
+RUN curl --fail https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path
+
+# Install dfx
+COPY dfx.json ./
+RUN DFXVM_INIT_YES=1 DFX_VERSION=$(cat dfx.json | jq -r .dfx) sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
+ENV export PATH=${HOME}/.local/share/dfx/bin:${PATH}
+
+COPY . .
+
+# Build
+RUN make build
+
+ENTRYPOINT [ "./release.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+build:
+	./build.sh codelta_backend
+
+
+release:
+	docker build -t codelta_backend .
+	mkdir -p $(shell pwd)/release-artifacts
+	docker run --rm -v $(shell pwd)/release-artifacts:/target/wasm32-unknown-unknown/release codelta_backend
+	shasum -a 256 $(shell pwd)/release-artifacts/codelta_backend.wasm  | cut -d ' ' -f 1

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Similar to `check_status` (above) but this method displays the ICP balance held 
 #### distribute_icp
 The primary purpose of the codelta_backend canister is to act as a decentralised entity that can accept voting rewards (ICP that can be held by the canister's default account). A `distribute_icp` method is provided, but can be called by no other principal than the canister controller. Given that the backend canister's controller is the threshold canister, distributing this ICP therefore requires a `distribute_icp` proposal and CO.DELTA member consensus. This setup is intended to faciliate equal shares of the rewards periodically distributed to each member. This is to incentivise their NNS governance participation via the CO.DELTA neuron. See the 'Neuron Configuration' section below. Also see the [Grants for Voting Neurons](https://forum.dfinity.org/t/grants-for-voting-neurons/32721) initiative for context.
 
+### How to verify CO.DELTA build
+Verify build to be sure you are interacting with codebase that matches with release.
+Pull the last release version.
+
+make release
+
+Verify it is same build as here https://dashboard.internetcomputer.org/canister/qkgir-uyaaa-aaaar-qaonq-cai
+
 **Both the frontend and backend canisters are controlled by the threshold canister**, which is what provides the decentralisation guarantee (that no individual member of CO.DELTA can exert unilateral control over the canisters, its funds, nor the neuron).
 
 ## threshold
@@ -64,6 +72,16 @@ graph LR
 The threshold canister is what allows the other canisters to be managed in a decentralised manner, requiring a vote from team members in order to upgrade the canister or disburse ICP.
 
 Although self-upgrades are supported, if an upgrade of the threshold canister is ever needed, the plan would be to initialise a second threshold canister with the same configuration (as a fallback). Threshold canister A would then need to assign joint control to threshold canister B (an operation that would require a proposal and consensus). This would act as a safety measure, allowing recovery from botched threshold canister upgrades (just in case).
+
+### Verify threshold build
+Verify build to be sure you are interacting with codebase that matches with release.
+Pull the last release version.
+
+dfx deploy threshold --with-cycles 80000000000 --argument='(vec {principal "'$(dfx identity get-principal)'"; principal "2vxsx-fae"; })'
+
+shasum -a 256 .dfx/local/canisters/threshold/threshold.wasm 
+
+Verify it is same build as here https://dashboard.internetcomputer.org/canister/6g7za-ziaaa-aaaar-qaqja-cai
 
 # Settings
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+FEATURES="${FEATURES:-}"
+echo "Features: $FEATURES"
+
+for pkg in $1; do
+    cargo build -q --target wasm32-unknown-unknown --release --package $pkg --features "$FEATURES" --locked
+    WASM_FILE=target/wasm32-unknown-unknown/release/$pkg.wasm
+    ic-wasm $WASM_FILE -o $WASM_FILE shrink
+    gzip -nf9v $WASM_FILE
+done

--- a/dfx.json
+++ b/dfx.json
@@ -23,5 +23,6 @@
     }
   },
   "output_env_file": ".env",
+  "dfx": "0.25.0",
   "version": 1
 }

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export PATH=${HOME}/.local/share/dfx/bin:${PATH}
+
+make build
+dfx start --background
+dfx deploy
+dfx canister info codelta_backend
+dfx stop

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.0"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
- Try to make reproducable binary build. Note that docker build process is quite bad at the moment.

See toolchain file:

- dfx 0.25.0
- rustc 1.85.0

Platform (see Dockerfile)
- `platform=linux/amd64 ubuntu:24.04`

Run `make release` and see. I get this hash

```
shasum -a 256 /home/user/CO.DELTA/release-artifacts/codelta_backend.wasm  | cut -d ' ' -f 1

0842e8166110afbcd4d3d7687e7b94b809fc8aa070a5fa7068273146c5a225d6

```

- Add verify instructions to readme